### PR TITLE
ci(codeql): add top-level minimal token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '21 3 * * 1'
 
+permissions: {}
+
 jobs:
   analyze:
     permissions:


### PR DESCRIPTION
## Summary
- add `permissions: {}` at the top level of `codeql.yml`

## Why
OpenSSF Scorecard flags the workflow for missing a top-level token-permissions baseline. The job already declares the specific permissions it needs, so adding an empty top-level default is the least-privilege fix.
