### PR TITLE
fix(generator): use compatible Blobs reads

### DIFF
--- a/netlify/functions/lib/asyncJobStore.js
+++ b/netlify/functions/lib/asyncJobStore.js
@@ -271,13 +271,13 @@ class NetlifyBlobsJobAdapter {
   async get(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
-    return this.store.get(safe, { type: 'json', consistency: 'strong' });
+    return this.store.get(safe, { type: 'json' });
   }
 
   async getVersioned(jobId) {
     const safe = sanitizeJobId(jobId);
     if (!safe) return null;
-    const result = await this.store.getWithMetadata(safe, { type: 'json', consistency: 'strong' });
+    const result = await this.store.getWithMetadata(safe, { type: 'json' });
     if (!result) return null;
     return { job: result.data, version: result.etag };
   }


### PR DESCRIPTION
Fixes production `BlobsConsistencyError` failures by removing unsupported strong-consistency reads. ETag-conditional writes remain intact.

Validated in Dev: 30 suites, 309 tests.