### PR TITLE
fix(generator): restore async quiz quality guidance

### DIFF
--- a/netlify/functions/lib/asyncGenerationWorker.js
+++ b/netlify/functions/lib/asyncGenerationWorker.js
@@ -136,7 +136,13 @@ function summarizeRejections(reasons) {
   }, {});
 }
 
-function collectUniqueQuizLines(rawLines, state, limit) {
+function hasSourceFraming(stem) {
+  const text = String(stem || '');
+  return /\b(?:according to|based (?:solely )?on)\s+(?:the\s+)?(?:provided\s+)?(?:[\w-]+\s+){0,3}(?:notes?|source material|study material|documentation|document|text|excerpts?|handout|reading|lesson)\b/i.test(text)
+    || /\b(?:the\s+)?(?:[\w-]+\s+){0,2}notes?\s+(?:state|states|say|says|indicate|indicates)\b/i.test(text);
+}
+
+function collectUniqueQuizLines(rawLines, state, limit, options = {}) {
   const raw = splitLines(rawLines);
   const accepted = [];
   const acceptedRecords = [];
@@ -155,6 +161,10 @@ function collectUniqueQuizLines(rawLines, state, limit) {
     const key = normalizedStem(stem);
     if (!stem || !key) {
       rejectedReasons.push('missing_stem');
+      continue;
+    }
+    if (options.sourceBacked && hasSourceFraming(stem)) {
+      rejectedReasons.push('source_framing');
       continue;
     }
     if (localSeen.has(key)) {
@@ -587,7 +597,9 @@ async function processOneBatch(store, job, batch, state, options = {}) {
     if (target <= 0 || requestedCount <= 0) return { stopped: false };
     const providerBatch = alignPlannedBatchForProvider(batch, requestedCount);
     const body = await runGenerateBatch(job, providerBatch, state);
-    const collection = collectUniqueQuizLines(body.lines, state, target);
+    const collection = collectUniqueQuizLines(body.lines, state, target, {
+      sourceBacked: !!providerBatch.sourceText,
+    });
     const accepted = collection.accepted;
     state.acceptedCount += accepted.length;
     if (accepted.length) {

--- a/netlify/functions/lib/providers.js
+++ b/netlify/functions/lib/providers.js
@@ -272,8 +272,13 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
   const contract = normalizeLaneContract(laneContract, count, types);
   if (!contract) return '';
   const source = cleanSourceMaterial(sourceText);
+  const diffLine = difficultyGuidance(difficulty);
+  const sourceBlock = source ? privateInstructorKnowledgeBlock(source) : '';
   const avoid = Array.isArray(avoidStems) && avoidStems.length
-    ? `Avoid repeating these already-used question stems: ${avoidStems.slice(-60).join(' | ')}.`
+    ? [
+      `Avoid repeating these already-used question stems: ${avoidStems.slice(-60).join(' | ')}.`,
+      `Test a meaningfully different underlying concept, answer, command, or behavior; do not merely paraphrase an avoided stem.`,
+    ].join('\n')
     : '';
   const curveballLine = contract.curveball
     ? `Curveball: create exactly ${Math.max(1, contract.curveballCount)} fair expert curveball in this batch. It must be source-grounded, test an edge case, exception, misleading assumption, or hidden dependency, and have one clearly correct answer.`
@@ -289,8 +294,11 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
     curveballLine,
     '',
     'Task:',
-    `${laneTaskLine(contract)} about ${topic}.`,
-    source ? 'Use only the source excerpts below.' : '',
+    laneTaskLine(contract),
+    source ? '' : `Quiz topic: ${topic}.`,
+    source ? sourceFramingInstructions() : '',
+    source ? 'Use only the private instructor knowledge below for factual content.' : '',
+    diffLine,
     contract.scenario ? 'Keep scenarios short and answerable.' : 'Do not add scenario framing; use direct standalone stems.',
     `Return only valid EZ Quiz ${contract.questionType} lines.`,
     'No explanations.',
@@ -300,9 +308,7 @@ function buildLanePrompt(topic, count, types, difficulty, avoidStems, sourceText
     '',
     'Output format:',
     lineFormatForType(contract.questionType),
-    source ? '' : '',
-    source ? 'Source excerpts:' : '',
-    source || '',
+    sourceBlock,
   ].filter((line) => line !== '').join('\n');
 }
 


### PR DESCRIPTION
Production quality fix mirrored from seanyates76/Ez-Quiz-Dev#179.

Restores difficulty and hidden-source guidance in compact async lane prompts, strengthens concept-level avoidance, and rejects/replaces source-framed stems such as “According to the CCNA Notes.”

Private validation: 30 suites, 316 tests; CI and dependency review green; Copilot reviewed all changed files with no findings.